### PR TITLE
Only fetch pool/token info for swaps that are actual sandwiches

### DIFF
--- a/src/core/swaps.ts
+++ b/src/core/swaps.ts
@@ -6,7 +6,6 @@ import { BigNumber } from 'ethers';
 
 import { getLogs } from './logs';
 import * as ABIs from './abis';
-import { Pool } from './pools';
 
 export enum SwapDir {
     ZeroToOne,
@@ -21,7 +20,6 @@ interface SwapParams {
     amount1Out: BigNumber;
     to: string;
     event: string;
-    pool: Pool;
     dir: SwapDir;
 }
 
@@ -123,17 +121,9 @@ export async function getSwaps(
                 ...bignums,
                 ..._.pick(decoded, ['sender', 'to', 'event']),
                 dir,
-                pool: null,
             },
         };
     });
-    for (const log of swaplogs) {
-        log.swap.pool = await Pool.lookupOrCreate(log.address);
-        if (log.swap.pool === null) {
-            throw new Error('null pool');
-        }
-    }
-
     const sorted = _.sortBy(swaplogs, 'blockNumber', 'transactionIndex');
     if (!_.isEqual(sorted, swaplogs)) {
         // don't expect this to happen, but check for sanity.


### PR DESCRIPTION
This reduces our number of contract read calls by an order of magnitude for cold passes on "typical" wallets. Roughly a 2x speedup on 0xb1.

fixes #21 