### PR TITLE
Misc follow-on improvements from #30 (SwapExactTokensForEth)

### DIFF
--- a/scripts/search.ts
+++ b/scripts/search.ts
@@ -4,9 +4,7 @@ import yargs from 'yargs';
 // import { Readable } from 'stream';
 
 import { config } from '../src/config/config';
-import { getSwaps } from '../src/core/swaps';
-import { findSandwich } from '../src/core/sandwich';
-import { addresses } from '../src/core/addresses';
+import { detect } from '../src/core/detector';
 import { init as initPool } from '../src/core/pools';
 
 const argv = yargs
@@ -67,23 +65,6 @@ const log = winston.createLogger({
     const from = argv.from;
     const to = argv.to == 'latest' ? await web3.eth.getBlockNumber() : argv.to;
     const wallet = argv.address as string;
-    const swaps = await getSwaps(
-        web3,
-        log,
-        null, // all pools
-        addresses.uniswapV2Router,
-        wallet,
-        from,
-        to,
-    );
-    log.info({
-        message: 'Found  Uniswap swaps',
-        n: swaps.length,
-        wallet: wallet,
-    });
-    log.info({ message: 'Now searching for sandwiches' });
-    for (const userSwap of swaps) {
-        const sws = await findSandwich(web3, log, userSwap, argv.window);
-        sws.forEach((sw) => log.info(sw));
-    }
+
+    await detect(web3, log, (o) => console.log(o), wallet, from, to);
 })();

--- a/src/core/detector.ts
+++ b/src/core/detector.ts
@@ -6,6 +6,7 @@ import { addresses } from './addresses';
 import { decodeSwapLog, getSwaps, SwapLog } from './swaps';
 import { getTransfers, TransferLog } from './transfers';
 import { findSandwich } from './sandwich';
+import { Pool } from './pools';
 import { uniswapPairs } from './uniswap-pair-list';
 import * as ABIs from './abis';
 
@@ -94,7 +95,8 @@ export async function detect(
             // see if this transfer is to a known uniswap pool, which would
             // be a strong hint that this is a swap. This is an optimization
             // to avoid calling getTransactionreceipt on every transfer we find.
-            if (!uniswapPairs.includes(transfer.transfer.to.toLowerCase())) {
+            const maybePool = transfer.transfer.to.toLowerCase();
+            if (!uniswapPairs.includes(maybePool) && !Pool.lookup(maybePool)) {
                 continue;
             }
             const receipt = await web3.eth.getTransactionReceipt(

--- a/src/core/pools.ts
+++ b/src/core/pools.ts
@@ -41,6 +41,10 @@ export class Pool {
         }[factory];
     }
 
+    static lookup(address: string): Pool | undefined {
+        return Pool.cache[address];
+    }
+
     static async lookupOrCreate(address: string): Promise<Pool> {
         if (Pool.cache[address] !== undefined) {
             return Pool.cache[address];

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -141,6 +141,14 @@ describe('sandwiched-wtf API', () => {
             });
         });
 
+        test('does not return dupes for sandwiches that are found both via Swap and Transfer', async () => {
+            const block = 11907091;
+            const res = await request(app).get(url(block)).expect(200);
+            const messages = parseResponse(res.text);
+            const sws = sandwiches(messages);
+            expect(sws.length).toEqual(1);
+        });
+
         test('sets mev flag on bundle sandwich', async () => {
             const block = 12205788;
             const res = await request(app).get(url(block)).expect(200);


### PR DESCRIPTION
- When checking the address of a Transfer to see if it looks like a
uniswap pair, check against the Pool cache (in addition to the static
list).

- Add a test for dupe suppression

- refactor scripts/search.ts to use `detect()`, like the express
handler.