### PR TITLE
Compute profits in both directions

### DIFF
--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,5 +1,6 @@
 import { agent as request } from 'supertest';
 import { app } from '../src/app';
+import { Sandwich } from '../src/core/sandwich';
 
 type message = { [key: string]: string };
 
@@ -10,29 +11,13 @@ function parseResponse(text: string): message[] {
         .map((line) => JSON.parse(line));
 }
 
-function sandwiches(messages: message[]): message[] {
-    return messages.filter((message) => message.targetTx != undefined);
+function isSandwich(o: any): o is Sandwich {
+    return 'targetTx' in o;
 }
 
-const picker = ({
-    message,
-    openTx,
-    targetTx,
-    closeTx,
-    pool,
-    profit,
-    profitCurrency,
-    mev,
-}: message) => ({
-    message,
-    openTx,
-    targetTx,
-    closeTx,
-    pool,
-    profit,
-    profitCurrency,
-    mev,
-});
+function sandwiches(messages: any): Sandwich[] {
+    return messages.filter(isSandwich);
+}
 
 describe('sandwiched-wtf API', () => {
     const Oxb1 = '0xb1adceddb2941033a090dd166a462fe1c2029484';
@@ -63,7 +48,7 @@ describe('sandwiched-wtf API', () => {
             const messages = parseResponse(res.text);
             const sws = sandwiches(messages);
             expect(sws.length).toEqual(1);
-            expect(picker(sws[0])).toEqual({
+            expect(sws[0]).toEqual({
                 message: 'Sandwich found',
                 openTx:
                     '0x0bcd7d7fd9895023002c5181d39e5de167ee179813dc63c385d5e64d26758ec1',
@@ -71,8 +56,7 @@ describe('sandwiched-wtf API', () => {
                     '0x320fbc4a1de7324a39278aa8213f392364a6dd0546b62fd45f2ccb84558598bf',
                 closeTx:
                     '0x53d2e9170eb2a21330ddbfc5a4e9e02e31de3e76738cd1659946256abcb417f7',
-                profit: '1.770266036457971241',
-                profitCurrency: 'WETH',
+                profit: { amount: '1.770266036457971241', currency: 'WETH' },
                 pool: 'WETH - B20',
                 mev: false,
             });
@@ -84,7 +68,7 @@ describe('sandwiched-wtf API', () => {
             const messages = parseResponse(res.text);
             const sws = sandwiches(messages);
             expect(sws.length).toEqual(1);
-            expect(picker(sws[0])).toEqual({
+            expect(sws[0]).toEqual({
                 message: 'Sandwich found',
                 openTx:
                     '0x699de2603b40fea219afeccf388ea6c66b36758d89ab1eebb3324239ee442378',
@@ -92,8 +76,7 @@ describe('sandwiched-wtf API', () => {
                     '0xd82a86f8324fba7e0d374b461d6faf0c39a0d53fde06505d6c2cb8447609c617',
                 closeTx:
                     '0x62fedc4df9aebe7cdf7965fe1e35de7d657c94db2c55551c1954eb823a0351b6',
-                profit: '14.320954423950744728',
-                profitCurrency: 'WETH',
+                profit: { amount: '14.320954423950744728', currency: 'WETH' },
                 pool: 'FARM - WETH',
                 mev: false,
             });
@@ -105,7 +88,7 @@ describe('sandwiched-wtf API', () => {
             const messages = parseResponse(res.text);
             const sws = sandwiches(messages);
             expect(sws.length).toEqual(1);
-            expect(picker(sws[0])).toEqual({
+            expect(sws[0]).toEqual({
                 message: 'Sandwich found',
                 openTx:
                     '0xe1f01378c5e9e825bd428cd755e68e01f46314a0d7926c940cd9218578a12139',
@@ -113,8 +96,7 @@ describe('sandwiched-wtf API', () => {
                     '0x68dd28d3ce2a5ef90680f5b4e3b86af2501973d2107b642f0f075d92131a56c5',
                 closeTx:
                     '0x5a54f6726c168aedf1171ce686dd5d05d03bb99de212e30d5da05ea316bdec64',
-                profit: '1.026020662373103583',
-                profitCurrency: 'ibETH',
+                profit: { amount: '1.026020662373103583', currency: 'ibETH' },
                 pool: 'ibETH - ALPHA',
                 mev: false,
             });
@@ -126,7 +108,7 @@ describe('sandwiched-wtf API', () => {
             const messages = parseResponse(res.text);
             const sws = sandwiches(messages);
             expect(sws.length).toEqual(1);
-            expect(picker(sws[0])).toEqual({
+            expect(sws[0]).toEqual({
                 message: 'Sandwich found',
                 openTx:
                     '0x81702040406fb63a7a1b1ec1a895c9d1357637f5bc2381fed34dba27e7880b18',
@@ -134,8 +116,14 @@ describe('sandwiched-wtf API', () => {
                     '0xef82677d92db48e8285b9541584531e3cd53137213217257c705ce307d0e2a7e',
                 closeTx:
                     '0xfcf39b2ac09995aa8cbe8075f5cdbf6d6f37043d5c6f1955966c2d63ae43852f',
-                profit: '2599.826136379271345974',
-                profitCurrency: 'GYSR',
+                profit: { amount: '2599.826136379271345974', currency: 'GYSR' },
+                // By happenstance this one has a backward profit as well as a
+                // forward profit. This wasn't explicitly the purpose of this test
+                // and was discovered after backward profit was added.
+                profit2: {
+                    amount: '0.039801656813635224',
+                    currency: 'WETH',
+                },
                 pool: 'GYSR - WETH',
                 mev: false,
             });
@@ -155,7 +143,7 @@ describe('sandwiched-wtf API', () => {
             const messages = parseResponse(res.text);
             const sws = sandwiches(messages);
             expect(sws.length).toEqual(1);
-            expect(picker(sws[0]).mev).toEqual(true);
+            expect(sws[0].mev).toEqual(true);
         });
 
         test('computes correct profit when non-standard (non-18) decimals', async () => {
@@ -164,7 +152,20 @@ describe('sandwiched-wtf API', () => {
             const messages = parseResponse(res.text);
             const sws = sandwiches(messages);
             expect(sws.length).toEqual(1);
-            expect(picker(sws[0]).profit).toEqual('3344.067039');
+            expect(sws[0].profit.amount).toEqual('3344.067039');
+        });
+
+        test('computes backward profit correctly', async () => {
+            const block = 11380276;
+            const res = await request(app).get(url(block)).expect(200);
+            const messages = parseResponse(res.text);
+            const sws = sandwiches(messages);
+            expect(sws.length).toEqual(1);
+            expect(sws[0].profit).toEqual({ amount: '0.0', currency: 'ROOK' });
+            expect(sws[0].profit2).toEqual({
+                amount: '0.167365394662967763',
+                currency: 'WETH',
+            });
         });
 
         test('takes into account transaction position in block (bug #19 fix)', async () => {


### PR DESCRIPTION
Previously, we only considered the case where the trader made a profit
in the 'natural' forward direction:

- open "swap x tok1 for n tok2",
- (target swap tok1 for tok2)
- close "swap n tok2 for y tok1"

where `y-x` is the profit (in tok1). This makes most sense when tok1 is
ETH.

But it is also possible to take a profit in the other direction:

- open "swap n tok1 for x tok2",
- (target swap tok1 for tok2)
- close "swap y tok2 for n tok1"

where `x-y` is the profit (in tok2). This makes most sense when tok2 is ETH, and
the transaction being sandwiched is swapExactTokensForEth.