### PR TITLE
Remove the "checkMismatched" check

### DIFF
--- a/src/core/sandwich.ts
+++ b/src/core/sandwich.ts
@@ -72,10 +72,6 @@ export async function findSandwich(
         }
 
         const close = closes[0];
-        if (checkMismatched(log, open, target, close)) {
-            continue;
-        }
-
         const pool = await Pool.lookupOrCreate(open.address);
         if (pool === null) {
             throw new Error('null pool');
@@ -161,30 +157,4 @@ function logMultipleClose(
         target.transactionHash,
         ...closes.map((close) => close.transactionHash),
     ]);
-}
-
-function checkMismatched(
-    log: winston.Logger,
-    open: SwapLog,
-    target: SwapLog,
-    close: SwapLog,
-): boolean {
-    let a: BigNumber, b: BigNumber;
-    if (open.swap.dir == SwapDir.ZeroToOne) {
-        a = open.swap.amount1Out;
-        b = close.swap.amount1In;
-    } else {
-        a = open.swap.amount0Out;
-        b = close.swap.amount0In;
-    }
-    if (b.lt(a.mul(99).div(101)) || b.gt(a.mul(101).div(99))) {
-        logWeird(log, 'gap (>5%) in sandwich open/close amounts', [
-            open.transactionHash,
-            target.transactionHash,
-            close.transactionHash,
-            utils.formatEther(b.sub(a)), // xxx decimals
-        ]);
-        return true;
-    }
-    return false;
 }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -155,15 +155,41 @@ describe('sandwiched-wtf API', () => {
             expect(sws[0].profit.amount).toEqual('3344.067039');
         });
 
-        test('computes backward profit correctly', async () => {
+        test('finds double sandwich (interleaved) and computes backward profit correctly', async () => {
+            // It so happened that this tx has two sandwiches that both have
+            // backward profits, so we test them together, but this doesn't mean
+            // that double-sandwiches and backward profits are otherwise
+            // linked...
             const block = 11380276;
             const res = await request(app).get(url(block)).expect(200);
             const messages = parseResponse(res.text);
             const sws = sandwiches(messages);
-            expect(sws.length).toEqual(1);
+            expect(sws.length).toEqual(2);
+
             expect(sws[0].profit).toEqual({ amount: '0.0', currency: 'ROOK' });
             expect(sws[0].profit2).toEqual({
+                amount: '0.197375949528145637',
+                currency: 'WETH',
+            });
+            expect(sws[1].profit).toEqual({ amount: '0.0', currency: 'ROOK' });
+            expect(sws[1].profit2).toEqual({
                 amount: '0.167365394662967763',
+                currency: 'WETH',
+            });
+        });
+
+        test('finds double sandwich (non-interleaved) and computes profits correctly', async () => {
+            const block = 11972504;
+            const res = await request(app).get(url(block)).expect(200);
+            const messages = parseResponse(res.text);
+            const sws = sandwiches(messages);
+            expect(sws.length).toEqual(2);
+            expect(sws[0].profit).toEqual({
+                amount: '0.128048512336962075',
+                currency: 'WETH',
+            });
+            expect(sws[1].profit).toEqual({
+                amount: '1.21808712279187822',
                 currency: 'WETH',
             });
         });


### PR DESCRIPTION
This check was an artefact of our prior unawareness of backward
profits.

Also, this uncovered some double-sandwiches that weren't being
reported in tests. So adjust test for those, and add another double
sandwich test while we're at it.

(note: double sandwiches and checkMismatched aren't intrinsically
related... this should really have been two commits).

close #33 