### PR TITLE
Fix express error handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "node": ">= 14.16"
     },
     "scripts": {
-        "start": "node dist/src/index.js",
+        "start": "NODE_ENV=production node dist/src/index.js",
         "dev": "NODE_ENV=development nodemon node dist/src/index.js",
         "clean": "rimraf coverage dist tmp",
         "build": "tsc -p tsconfig.json",

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,10 @@ export const app: express.Application = express();
 
 const web3 = new Web3(config.web3_url);
 
+for (const item in config) {
+    logger.info(`${item}: ${config[item]}`);
+}
+
 (async () => {
     try {
         await initPool(web3, logger, redis.createClient(config.redis_url));
@@ -122,15 +126,17 @@ app.use(
     },
 );
 
-app.use(((err, _req: express.Request, res: express.Response) => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+app.use(((err, _req: express.Request, res: express.Response, _next) => {
+    if (res.statusCode !== undefined) {
+        return _next(err);
+    }
     err.statusCode = 500;
     if (config.env === 'production') {
         err.message = 'internal server error';
         err.stack = undefined;
     }
 
-    if (config.env === 'development') {
-        logger.error(err);
-    }
+    logger.error(err);
     res.status(500).send(err);
 }) as express.ErrorRequestHandler);


### PR DESCRIPTION
It was missing the fourth param and hence wasn't being used as an
error handler by express.

Also
- fixed "npm run start" to set NODE_ENV=production
- log all config items at startup


close #6 