### PR TITLE
Use Content-Type: application/json for errors

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -126,7 +126,8 @@ app.use(
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 app.use(((err, _req: express.Request, res: express.Response, _next) => {
     if (res.statusCode !== undefined) {
-        return _next(err);
+        res.json(err.toString());
+        return;
     }
     err.statusCode = 500;
     if (config.env === 'production') {
@@ -135,5 +136,5 @@ app.use(((err, _req: express.Request, res: express.Response, _next) => {
     }
 
     logger.error(err);
-    res.status(500).send(err);
+    res.status(500).json(err);
 }) as express.ErrorRequestHandler);

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -41,6 +41,7 @@ describe('sandwiched-wtf API', () => {
         test('returns 400 for bad address', async () => {
             const resp = await request(app).get(`/sandwiches/Ox123456789`);
             expect(resp.status).toEqual(400);
+            expect(resp.type).toEqual('application/json');
         });
 
         test('returns 400 for bad to/from block', async () => {
@@ -48,6 +49,7 @@ describe('sandwiched-wtf API', () => {
                 `/sandwiches/${Oxb1}?fromBlock=foo&toBlock=200`,
             );
             expect(resp.status).toEqual(400);
+            expect(resp.type).toEqual('application/json');
         });
     });
 


### PR DESCRIPTION
(We were returning an html rendered error).