### PR TITLE
Rearrange profits

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -134,7 +134,12 @@ app.use(
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 app.use(((err, _req: express.Request, res: express.Response, _next) => {
+    logger.error(err);
     if (res.statusCode !== undefined) {
+        if (res.headersSent) {
+            res.write(err.toString());
+            return;
+        }
         res.json(err.toString());
         return;
     }
@@ -144,6 +149,5 @@ app.use(((err, _req: express.Request, res: express.Response, _next) => {
         err.stack = undefined;
     }
 
-    logger.error(err);
     res.status(500).json(err);
 }) as express.ErrorRequestHandler);

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -275,16 +275,16 @@ describe('sandwiched-wtf API', () => {
             const sws = sandwiches(messages);
             expect(sws.length).toEqual(2);
 
-            expect(sws[0].profit).toEqual({ amount: '0.0', currency: 'ROOK' });
-            expect(sws[0].profit2).toEqual({
+            expect(sws[0].profit).toEqual({
                 amount: '0.197375949528145637',
                 currency: 'WETH',
             });
-            expect(sws[1].profit).toEqual({ amount: '0.0', currency: 'ROOK' });
-            expect(sws[1].profit2).toEqual({
+            expect(sws[0].profit2).toBeUndefined();
+            expect(sws[1].profit).toEqual({
                 amount: '0.167365394662967763',
                 currency: 'WETH',
             });
+            expect(sws[1].profit2).toBeUndefined();
         });
 
         test('finds double sandwich (non-interleaved) and computes profits correctly', async () => {


### PR DESCRIPTION
Previously, '.profit' and '.profit2' held the forward and
backward profit. The backward profit was dropped if zero but the
forward wasn't, which is inconsistent. Furthermore, the distincgion of
"forward" and "backward" isn't really important for the FE app at this
point.

Consequently, this PR changes things to drop any zero
profit (regardless of forward or backward). As a result, the backward
profit can be in '.profit'.